### PR TITLE
Allow CR expansion for arbitrary line suffix

### DIFF
--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -405,10 +405,9 @@ function! delimitMate#ExpandReturn() "{{{
 	if delimitMate#WithinEmptyPair()
 		" Expand:
 		call delimitMate#FlushBuffer()
-		let char = delimitMate#GetCharFromCursor(0)
-		"return "\<Esc>a\<CR>x\<CR>\<Esc>k$\"_xa"
-		"return "\<Esc>a\<CR>\<UP>\<Esc>o"
-		call feedkeys("\<Esc>a\<Del>\<Esc>ox\<BS>\<CR>".char."\<Esc>kA", 't')
+
+		let b:delimitMate_lineSuffix = getline('.')[col('.')-1:]
+		call feedkeys("\<Esc>l\"_Do \<CR>\<C-R>\<C-R>=b:delimitMate_lineSuffix\<CR>\<Esc>k$i\<Del>", 't')
 		return ''
 	else
 		return "\<CR>"


### PR DESCRIPTION
The current CR expansion mechanism has a limitation: it checks only the character after the cursor. It causes the following problem: (typical JavaScript code):

```
$(document).ready(function() {<cursor>})
```

When the user presses `<CR>`, the result is the following:

```
$(document.ready(function() {)
    <cursor>
}
```

This commit fixes this problem by pasting the whole line suffix (`})`) to the last line.
