### PR TITLE
Add C-h synonym for delimitMateBS

### DIFF
--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -178,7 +178,7 @@ function! s:Unmap() " {{{
 				\ s:g('left_delims') +
 				\ s:g('quotes_list') +
 				\ s:g('apostrophes_list') +
-				\ ['<BS>', '<S-BS>', '<Del>', '<CR>', '<Space>', '<S-Tab>', '<Esc>'] +
+				\ ['<BS>', '<C-h>', '<S-BS>', '<Del>', '<CR>', '<Space>', '<S-Tab>', '<Esc>'] +
 				\ ['<Up>', '<Down>', '<Left>', '<Right>', '<LeftMouse>', '<RightMouse>'] +
 				\ ['<C-Left>', '<C-Right>'] +
 				\ ['<Home>', '<End>', '<PageUp>', '<PageDown>', '<S-Down>', '<S-Up>', '<C-G>g']
@@ -305,8 +305,13 @@ endfunction "}}}
 function! s:ExtraMappings() "{{{
 	" If pair is empty, delete both delimiters:
 	inoremap <silent> <Plug>delimitMateBS <C-R>=delimitMate#BS()<CR>
-	if !hasmapto('<Plug>delimitMateBS','i') && maparg('<BS>'. 'i') == ''
-		silent! imap <unique> <buffer> <BS> <Plug>delimitMateBS
+	if !hasmapto('<Plug>delimitMateBS','i')
+	  if maparg('<BS>'. 'i') == ''
+      silent! imap <unique> <buffer> <BS> <Plug>delimitMateBS
+    endif
+	  if maparg('<C-h>'. 'i') == ''
+      silent! imap <unique> <buffer> <C-h> <Plug>delimitMateBS
+    endif
 	endif
 	" If pair is empty, delete closing delimiter:
 	inoremap <silent> <expr> <Plug>delimitMateS-BS delimitMate#WithinEmptyPair() ? "\<Del>" : "\<S-BS>"


### PR DESCRIPTION
When typing in insert mode, one often uses C-h interchangeably with <BS>. This is meant to add C-h support for delimitMateBS.

Tested on MacVim and console vim 7.4. Hopefully I haven't broken anything else.

Note: The same can't be done for delimiteMateS-BS, because vim cannot differentiate between C-h and C-H. Will have to live with that I suppose.
