### PR TITLE
Fix &ft check in QuoteDelim: handle dotted filetypes

### DIFF
--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -382,9 +382,9 @@ function! delimitMate#QuoteDelim(char) "{{{
 	elseif char_at == a:char
 		" Inside an empty pair, jump out
 		return a:char . "\<Del>"
-	elseif &ft == "vim" && a:char == '"' && getline('.') =~ '^\s*$'
+	elseif a:char == '"' && index(split(&ft, '\.'), "vim") != -1 && getline('.') =~ '^\s*$'
 		" If we are in a vim file and it looks like we're starting a comment, do
-		" not add a second
+		" not add a closing char.
 		return a:char
 	elseif delimitMate#IsSmartQuote(a:char)
 		" Seems like a smart quote, insert a single char.


### PR DESCRIPTION
From `:h 'filetype'`:

```
    When a dot appears in the value then this separates two filetype
    names.  Example:
        /* vim: set filetype=c.doxygen : */ ~
```

I am using `ft=pentadactyl.vim` for my Pentadactyl/Vimperator
configuration files.
