### PR TITLE
JumpOut: delete and insert char instead of jumping over [idea]

### DIFF
--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -413,7 +413,10 @@ function! delimitMate#JumpOut(char) "{{{
 	endif
 	let jump = delimitMate#ShouldJump(a:char)
 	if jump == 1
-		return "\<Right>"
+		" HACK: Instead of <Right>, we remove the char to be jumped over and
+		" insert it again. This will trigger re-indenting via 'indentkeys'.
+		" Ref: https://github.com/Raimondi/delimitMate/issues/168
+		return "\<Del>".a:char
 	elseif jump == 3
 		return "\<Right>\<Right>"
 	elseif jump == 5


### PR DESCRIPTION
I am proposing this as an idea: instead of jumping over the character, replace it.

This fixes https://github.com/Raimondi/delimitMate/issues/168 (where the char to be inserted triggers indentation).

It only covers one of the cases in JumpOut and should get adopted for others also (if this is a sensible approach).
