### PR TITLE
doc: only keys from delimitMate#OptionsList are used

### DIFF
--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -655,6 +655,7 @@ function! delimitMate#TestMappings() "{{{
 endfunction "}}}
 
 function! delimitMate#OptionsList() "{{{
+	" Note: only keys are used, via delimitMate#TestMappings.
 	return {
 				\ 'apostrophes'        : '',
 				\ 'autoclose'          : 1,


### PR DESCRIPTION
It would probably make sense to refactor this (and use the keys from the
actual default value - if this is possible and feasible). Currently it
looks like the values would be defaults or something similar.
