### PR TITLE
Fix undo via `<Esc>:undojoin<cr>i` (applied via `s:get_left_motion`)

### DIFF
--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -368,6 +368,11 @@ augroup delimitMate
 				\   call <SID>DelimitMateDo() |
 				\   let b:delimitMate_was_here = 1 |
 				\ endif
+
+	" Keep track of visualmode(), which is used in s:get_left_motion(),
+	" to skip leaving insert mode in block-wise visual mode.
+	autocmd InsertEnter * let b:delimitMate_visualmode = visualmode()
+	autocmd InsertLeave * unlet! b:delimitMate_visualmode
 augroup END
 
 "}}}


### PR DESCRIPTION
While this fixes the undo chaining in general, `<Left>` is still being
used in block-wise visual mode, where exiting insert mode would also
exit the block-wise mode.

Ref: https://github.com/Raimondi/delimitMate/issues/138