### PR TITLE
Make <Plug>delimitMateJumpMany to work with g:delimitMate_excluded_ft.

### DIFF
--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -332,7 +332,7 @@ function! s:ExtraMappings() "{{{
 		silent! imap <unique> <buffer> <S-Tab> <Plug>delimitMateS-Tab
 	endif
 	" Jump over next delimiters
-	inoremap <expr><buffer> <Plug>delimitMateJumpMany <SID>TriggerAbb()."\<C-R>=delimitMate#JumpMany()\<CR>"
+	inoremap <expr><silent> <Plug>delimitMateJumpMany <SID>TriggerAbb()."\<C-R>=delimitMate#JumpMany()\<CR>"
 	if !hasmapto('<Plug>delimitMateJumpMany', 'i') && maparg("<C-G>g", 'i') == ''
 		imap <silent> <buffer> <C-G>g <Plug>delimitMateJumpMany
 	endif


### PR DESCRIPTION
Hi, Raimond,
Thanks for the amazing plugin!
I change the mapping option of <Plug>delimitMateJumpMany to make <Plug>delimitMateJumpMany work with g:delimitMate_excluded_ft.

Thanks & Best Regards,

liangfeng

