### PR TITLE
Prevent errors inside excluded filetype

### DIFF
--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -196,7 +196,17 @@ function! s:get_syn_name() "{{{
   return synIDattr(synIDtrans(synID(line('.'), col, 1)), 'name')
 endfunction " }}}
 
+function! s:is_excluded_ft(ft) "{{{
+  if !exists("g:delimitMate_excluded_ft")
+    return 0
+  endif
+  return index(split(g:delimitMate_excluded_ft, ','), a:ft, 0, 1) >= 0
+endfunction "}}}
+
 function! s:is_forbidden(char) "{{{
+  if s:is_excluded_ft(&filetype)
+    return 1
+  endif
   if !s:get('excluded_regions_enabled')
     return 0
   endif


### PR DESCRIPTION
I am using `sexp` for editing `clojure` files and therefore wanted to disable `delimitMate` for this filetype. While adding the ft to `g:delimitMate_exluded_ft` correctly disabled all functionality, there were errors thrown when hitting enter. (This does not happen immediately when editing a single file, but after switching buffers.) This was due to insert mode mappings still triggering `delimitMate#ExpandReturn()` whith `g:delimitMate_expand_cr` being enabled. Obviously some dictionary lookups fail:

```viml
Error detected while processing function delimitMate#ExpandReturn..<SNR>53_is_forbidden..    <SNR>53_get:
line    7:
E716: Key not present in Dictionary: 3.excluded_regions_enabled
Error detected while processing function delimitMate#ExpandReturn..<SNR>53_get:
line    7:
E716: Key not present in Dictionary: 3.expand_cr
Error detected while processing function delimitMate#ExpandReturn..<SNR>53_get:
line    7:
E716: Key not present in Dictionary: 3.expand_inside_quotes
Error detected while processing function delimitMate#ExpandReturn..<SNR>53_is_empty_matchpair..<SNR>53_get:
line    7:
E716: Key not present in Dictionary: 3.left_delims
Error detected while processing function delimitMate#ExpandReturn..<SNR>53_is_empty_matchpair:
line    3:
E714: List required
```

I felt like it would be better to not execute the full command for disabled filetypes anyway, so I added a guard clause that will immediately return for excluded filetypes.
