### PR TITLE
fix maparg typo

### DIFF
--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -326,10 +326,10 @@ function! s:ExtraMappings() "{{{
   " If pair is empty, delete both delimiters:
   inoremap <silent> <Plug>delimitMateBS <C-R>=delimitMate#BS()<CR>
   if !hasmapto('<Plug>delimitMateBS','i')
-    if maparg('<BS>'. 'i') == ''
+    if maparg('<BS>', 'i') == ''
       silent! imap <unique> <buffer> <BS> <Plug>delimitMateBS
     endif
-    if maparg('<C-h>'. 'i') == ''
+    if maparg('<C-h>', 'i') == ''
       silent! imap <unique> <buffer> <C-h> <Plug>delimitMateBS
     endif
   endif


### PR DESCRIPTION
I found issue https://github.com/Raimondi/delimitMate/issues/204.
[This code](https://github.com/Raimondi/delimitMate/blob/c78a6e6d937333fed276bddc4589f6313e277a8e/plugin/delimitMate.vim#L329-L334):
```vim
    if maparg('<BS>'. 'i') == ''
      silent! imap <unique> <buffer> <BS> <Plug>delimitMateBS
    endif
    if maparg('<C-h>'. 'i') == ''
      silent! imap <unique> <buffer> <C-h> <Plug>delimitMateBS
    endif
```
doesn't work as intended. `maparg` really returns ant empty string, so the control flow enters the `if` statement, but due to `silent!`, error __"mapping already exists"__ is omitted. As @perrin4869 [noted](https://github.com/Raimondi/delimitMate/issues/204#issuecomment-71517649), comma should be used instead.
__Related issue__: (https://github.com/Raimondi/delimitMate/issues/204)