### PR TITLE
Don't check pum in TriggerAbb

### DIFF
--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -262,7 +262,6 @@ endfunction "}}}
 function! s:TriggerAbb() "{{{
   if v:version < 703
         \ || ( v:version == 703 && !has('patch489') )
-        \ || pumvisible()
     return ''
   endif
   return "\<C-]>"


### PR DESCRIPTION
This fixes an issue with expand cr with deoplete. I'm not sure if this breaks something, in which case this may want to become an option rather than just removing it.