### PR TITLE
Set delimitMate_nesting_quotes for Python by default

### DIFF
--- a/doc/delimitMate.txt
+++ b/doc/delimitMate.txt
@@ -191,6 +191,8 @@ e.g.: >
         let delimitMate_nesting_quotes = ['"','`']
         au FileType python let b:delimitMate_nesting_quotes = ['"']
 <
+For Python this is set by default by the plugin.
+
 ------------------------------------------------------------------------------
                                                      *'delimitMate_expand_cr'*
                                                    *'b:delimitMate_expand_cr'*

--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -383,6 +383,7 @@ augroup delimitMate
   au!
   " Run on file type change.
   au FileType * call <SID>setup()
+  au FileType python let b:delimitMate_nesting_quotes = ['"', "'"]
 
   " Run on new buffers.
   au BufNewFile,BufRead,BufEnter,CmdwinEnter *


### PR DESCRIPTION
I propose to make this the default. A GitHub search shows that 681 people have this in their dotfiles `.vimrc` anyway.

https://github.com/search?q=python+let+b%3AdelimitMate_nesting_quotes&type=code

Closes: #173