### PR TITLE
Add support for lisp/scheme, change augroup name in `plugin/delimitMate.vim`.

### DIFF
--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -1,5 +1,5 @@
 " File:        autoload/delimitMate.vim
-" Version:     2.7.1
+" Version:     2.8.1
 " Modified:    2013-07-15
 " Description: This plugin provides auto-completion for quotes, parens, etc.
 " Maintainer:  Israel Chauca F. <israelchauca@gmail.com>

--- a/autoload/delimitMate.vim
+++ b/autoload/delimitMate.vim
@@ -1,5 +1,5 @@
 " File:        autoload/delimitMate.vim
-" Version:     2.7
+" Version:     2.7.1
 " Modified:    2013-07-15
 " Description: This plugin provides auto-completion for quotes, parens, etc.
 " Maintainer:  Israel Chauca F. <israelchauca@gmail.com>

--- a/doc/delimitMate.txt
+++ b/doc/delimitMate.txt
@@ -1,4 +1,4 @@
-*delimitMate.txt*   Trying to keep those beasts at bay! v2.7.1   *delimitMate*
+*delimitMate.txt*   Trying to keep those beasts at bay! v2.8.1   *delimitMate*
 
 
 
@@ -805,6 +805,9 @@ This script was inspired by the auto-completion of delimiters on TextMate.
  11. HISTORY                                               *delimitMateHistory*
 
   Version      Date      Release notes                                       ~
+|---------|------------|-----------------------------------------------------|
+   2.8.1    2020-02-02 * Current release:
+                         - Add support for lisp/scheme.
 |---------|------------|-----------------------------------------------------|
     2.8     2013-07-15 * Current release:
                          - Add :DelimitMateOn & :DelimitMateOff.

--- a/doc/delimitMate.txt
+++ b/doc/delimitMate.txt
@@ -1,4 +1,4 @@
-*delimitMate.txt*   Trying to keep those beasts at bay! v2.7     *delimitMate*
+*delimitMate.txt*   Trying to keep those beasts at bay! v2.7.1   *delimitMate*
 
 
 

--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -1,5 +1,5 @@
 " File:        plugin/delimitMate.vim
-" Version:     2.7.1
+" Version:     2.8.1
 " Modified:    2022-02-02
 " Description: This plugin provides auto-completion for quotes, parens, etc.
 " Maintainer:  Israel Chauca F. <israelchauca@gmail.com>

--- a/plugin/delimitMate.vim
+++ b/plugin/delimitMate.vim
@@ -1,6 +1,6 @@
 " File:        plugin/delimitMate.vim
-" Version:     2.7
-" Modified:    2013-07-15
+" Version:     2.7.1
+" Modified:    2022-02-02
 " Description: This plugin provides auto-completion for quotes, parens, etc.
 " Maintainer:  Israel Chauca F. <israelchauca@gmail.com>
 " Manual:      Read ":help delimitMate".
@@ -379,11 +379,13 @@ command! -bar DelimitMateOff call s:setup(0)
 
 " Autocommands: {{{
 
-augroup delimitMate
+augroup __delimitMate__
   au!
   " Run on file type change.
   au FileType * call <SID>setup()
   au FileType python let b:delimitMate_nesting_quotes = ['"', "'"]
+  au FileType lisp,scheme let b:delimitMate_quotes = '"' |
+        \ let b:delimitMate_matchpairs = "(:)"
 
   " Run on new buffers.
   au BufNewFile,BufRead,BufEnter,CmdwinEnter *


### PR DESCRIPTION
- Add support for lisp/scheme:
```vim
  au FileType lisp,scheme let b:delimitMate_quotes = '"' |
        \ let b:delimitMate_matchpairs = "(:)"
```
- Change augroup name in `plugin/delimitMate.vim`.
- Change version number.